### PR TITLE
fix nil reference and key mismatch bugs; add more logs

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -613,7 +613,6 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 							ch.errCh <- err
 							return
 						}
-						// I think maybe this repo name has to be normalized, becasue blah == blah.git.
 						if _, ok := repoLocks[refSourceMapping.Repo.Repo]; !ok {
 							closer, err := s.repoLock.Lock(gitClient.Root(), targetRevision, true, func() (goio.Closer, error) {
 								return s.checkoutRevision(gitClient, targetRevision, s.initConstants.SubmoduleEnabled)

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -589,20 +589,31 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 	opContext, err := opContextSrc()
 	if err == nil {
 		if q.HasMultipleSources {
-			if q.ApplicationSource.IsHelm() {
+			if q.ApplicationSource.Helm != nil {
 				// Checkout every the referenced Source to the target revision before generating Manifests
 				for _, valueFile := range q.ApplicationSource.Helm.ValueFiles {
 					if strings.HasPrefix(valueFile, "$") {
 						refVar := strings.Split(valueFile, "/")[0]
-						refSourceKey := strings.TrimPrefix(refVar, "$")
 
-						refSourceMapping := q.RefSources[refSourceKey]
+						refSourceMapping, ok := q.RefSources[refVar]
+						if !ok {
+							var refKeys []string
+							for refKey, _ := range q.RefSources {
+								refKeys = append(refKeys, refKey)
+							}
+							if len(refKeys) == 0 {
+								ch.errCh <- fmt.Errorf("source referenced %q, but no source has a 'ref' field defined", refVar)
+							}
+							ch.errCh <- fmt.Errorf("source referenced %q, which is not one of the available sources (%s)", refVar, strings.Join(refKeys, ", "))
+							return
+						}
 						gitClient, targetRevision, err := s.newClientResolveRevision(&refSourceMapping.Repo, refSourceMapping.TargetRevision)
 						if err != nil {
 							log.Errorf("failed to get git client for repo %s", q.Repo.Repo)
 							ch.errCh <- err
 							return
 						}
+						// I think maybe this repo name has to be normalized, becasue blah == blah.git.
 						if _, ok := repoLocks[refSourceMapping.Repo.Repo]; !ok {
 							closer, err := s.repoLock.Lock(gitClient.Root(), targetRevision, true, func() (goio.Closer, error) {
 								return s.checkoutRevision(gitClient, targetRevision, s.initConstants.SubmoduleEnabled)


### PR DESCRIPTION
`q.ApplicationSource.IsHelm()` is meant to check whether the source is from a Helm repo, not necessarily a Helm chart (potentially stored in git). So I switched to checking whether the Helm key is present.

`q.RefSources` includes the `$` prefix in the keys, so I changed the logic to retain that prefix when accessing sources.

I also added logging to clarify errors.