### PR TITLE
Added unit tests

### DIFF
--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -1954,7 +1954,7 @@ func TestGenerateAppsUsingPullRequestGenerator(t *testing.T) {
 					},
 				},
 				Spec: argov1alpha1.ApplicationSpec{
-					Source: argov1alpha1.ApplicationSource{
+					Source: &argov1alpha1.ApplicationSource{
 						RepoURL:        "https://testurl/testRepo",
 						TargetRevision: "{{.head_short_sha}}",
 					},
@@ -1973,7 +1973,7 @@ func TestGenerateAppsUsingPullRequestGenerator(t *testing.T) {
 						},
 					},
 					Spec: v1alpha1.ApplicationSpec{
-						Source: v1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://testurl/testRepo",
 							TargetRevision: "089d92cb",
 						},

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -197,9 +197,6 @@ func (a *ApplicationSpec) GetSources() ApplicationSources {
 		return a.Sources
 	}
 	if a.Source != nil {
-		if a.Source == nil {
-			return ApplicationSources{}
-		}
 		return ApplicationSources{*a.Source}
 	}
 	return ApplicationSources{}

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -3304,3 +3304,83 @@ func TestApplicationSourcePluginParameters_Environ_all(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, environ, fmt.Sprintf("ARGOCD_APP_PARAMETERS=%s", paramsJson))
 }
+
+func getApplicationSpec() *ApplicationSpec {
+	return &ApplicationSpec{
+		Source: &ApplicationSource{
+			Path: "source",
+		}, Sources: ApplicationSources{
+			{
+				Path: "sources/source1",
+			}, {
+				Path: "sources/source2",
+			},
+		},
+	}
+}
+
+func TestGetSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		hasSources     bool
+		hasSource      bool
+		appSpec        *ApplicationSpec
+		expectedSource ApplicationSource
+	}{
+		{"GetSource with Source and Sources field present", true, true, getApplicationSpec(), ApplicationSource{Path: "sources/source1"}},
+		{"GetSource with only Sources field", true, false, getApplicationSpec(), ApplicationSource{Path: "sources/source1"}},
+		{"GetSource with only Source field", false, true, getApplicationSpec(), ApplicationSource{Path: "source"}},
+		{"GetSource with no Source and Sources field", false, false, getApplicationSpec(), ApplicationSource{}},
+	}
+	for _, testCase := range tests {
+		testCopy := testCase
+		t.Run(testCopy.name, func(t *testing.T) {
+			t.Parallel()
+			if !testCopy.hasSources {
+				testCopy.appSpec.Sources = nil
+			}
+			if !testCopy.hasSource {
+				testCopy.appSpec.Source = nil
+			}
+			source := testCopy.appSpec.GetSource()
+			assert.Equal(t, testCopy.expectedSource, source)
+		})
+	}
+}
+
+func TestGetSources(t *testing.T) {
+	tests := []struct {
+		name            string
+		hasSources      bool
+		hasSource       bool
+		appSpec         *ApplicationSpec
+		expectedSources ApplicationSources
+	}{
+		{"GetSources with Source and Sources field present", true, true, getApplicationSpec(), ApplicationSources{
+			{Path: "sources/source1"},
+			{Path: "sources/source2"},
+		}},
+		{"GetSources with only Sources field", true, false, getApplicationSpec(), ApplicationSources{
+			{Path: "sources/source1"},
+			{Path: "sources/source2"},
+		}},
+		{"GetSources with only Source field", false, true, getApplicationSpec(), ApplicationSources{
+			{Path: "source"},
+		}},
+		{"GetSources with no Source and Sources field", false, false, getApplicationSpec(), ApplicationSources{}},
+	}
+	for _, testCase := range tests {
+		testCopy := testCase
+		t.Run(testCopy.name, func(t *testing.T) {
+			t.Parallel()
+			if !testCopy.hasSources {
+				testCopy.appSpec.Sources = nil
+			}
+			if !testCopy.hasSource {
+				testCopy.appSpec.Source = nil
+			}
+			sources := testCopy.appSpec.GetSources()
+			assert.Equal(t, testCopy.expectedSources, sources)
+		})
+	}
+}

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -431,6 +431,7 @@ func ValidatePermissions(ctx context.Context, spec *argoappv1.ApplicationSpec, p
 		for _, source := range spec.Sources {
 			condition := validateSourcePermissions(ctx, source, proj, spec.Project, spec.HasMultipleSources())
 			if len(condition) > 0 {
+				conditions = append(conditions, condition...)
 				return conditions, nil
 			}
 


### PR DESCRIPTION
PR includes unit tests for

- GetRefSources
- validateSourcePermissions and ValidatePermissions for multi-source apps
- GetSource and GetSources in types.go
- reposerver’s GenerateManifests method for multi-source apps